### PR TITLE
Refactor to put all canvas-related functions in one Renderer class

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,25 +1,27 @@
-import {MediaStreamOscilloscope, getUserMedia} from "../dist/index";
+import {MediaStreamOscilloscope, getUserMedia, Renderer} from "../dist/index";
 
 let stats = document.querySelector(".status");
-let cvs   = cvs = document.querySelector(".cvs");
+let cvs   = document.querySelector(".cvs");
 
-function fancyGraph(ctx,width,height){
-    let backstrokeStyle = ctx.strokeStyle;
-    ctx.strokeStyle = "#444";
-    ctx.fillRect(0,0,width,height);
-    ctx.beginPath();
-    for(let i=0; i<width; i+=10){
-        ctx.moveTo(i,0);
-        ctx.lineTo(i,height);
+class FancyGraphRenderer extends Renderer{
+    primer(){
+        this.cctx.strokeStyle = "#444";
+        this.cctx.fillRect(0,0,this.width,this.height);
+        this.cctx.beginPath();
+        for(let i=0; i<this.width; i+=10){
+            this.cctx.moveTo(i,0);
+            this.cctx.lineTo(i,this.height);
+        }
+        for(let j=0; j<this.height; j+=10){
+            this.cctx.moveTo(0,j);
+            this.cctx.lineTo(this.width,j);
+        }
+        this.cctx.stroke();
+        this.cctx.strokeStyle = this.strokeStyle;
     }
-    for(let j=0; j<height; j+=10){
-        ctx.moveTo(0,j);
-        ctx.lineTo(width,j);
-    }
-    ctx.stroke();
-    ctx.strokeStyle = backstrokeStyle;
 }
 function startOsc(){
+    const renderer = new FancyGraphRenderer(cvs);
     getUserMedia({audio: true})
         .then(stream=>{
             if(!stream) {
@@ -31,7 +33,7 @@ function startOsc(){
             stats.classList.add("success");
             stats.classList.remove("error");
             stats.innerHTML = "Listening to your microphone, Try saying something";
-            let osc = new MediaStreamOscilloscope(stream, cvs, null, 2048, null, fancyGraph);
+            let osc = new MediaStreamOscilloscope(stream, renderer, null, 2048);
             osc.start();
             document.querySelector(".btn.pause").addEventListener("click",()=>{
                 stats.innerHTML = "Oscilloscope Paused";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webaudio-oscilloscope",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "keywords": [
     "webaudio",
     "oscilloscope",

--- a/tools/canvas_tools.js
+++ b/tools/canvas_tools.js
@@ -1,32 +1,43 @@
 const DEFAULT_FILL   = "#111111";
 const DEFAULT_STROKE = "#11ff11"; 
 const HLINE_COLOR    = "#555555";
-function _initCvs(ctx, width, height){
-    ctx.fillStyle   = DEFAULT_FILL;
-    ctx.strokeStyle = DEFAULT_STROKE;
-}
-function _primer(ctx, width, height){
-    ctx.fillRect(0,0,width,height);
-    ctx.strokeStyle = HLINE_COLOR;
-    ctx.beginPath();
-    ctx.moveTo(0, height / 2);
-    ctx.lineTo(width, height / 2);
-    ctx.stroke();
-    ctx.strokeStyle = DEFAULT_STROKE;
-}
-function _drawRawOsc(ctx,data,width,height){
-    ctx.beginPath();
-    for(let i=0; i < data.length; i++){
-        let x = i * (width * 1.0 / data.length); // need to fix x
-        let v = data[i] / 128.0;
-        let y = v * height / 2;
-        if(i === 0) ctx.moveTo(x,y);
-        else ctx.lineTo(x,y);
+class Renderer{
+    fillStyle = DEFAULT_FILL
+    strokeStyle = DEFAULT_STROKE
+    hlineColor = HLINE_COLOR
+    constructor(canvasElement){
+        this.cvs = canvasElement;
+        let {width = 300, height = 150} = this.cvs;
+        this.width = width;
+        this.height = height;
+        this.cctx = this.cvs.getContext("2d");
     }
-    ctx.stroke();
+    init(){
+    }
+    primer(){
+        this.cctx.fillRect(0,0,this.width,this.height);
+        this.cctx.strokeStyle = this.hlineColor;
+        this.cctx.beginPath();
+        this.cctx.moveTo(0, this.height / 2);
+        this.cctx.lineTo(this.width, this.height / 2);
+        this.cctx.stroke();
+        this.cctx.strokeStyle = this.strokeStyle;
+    }
+    osc(data){
+        this.cctx.beginPath();
+        for(let i=0; i < data.length; i++){
+            let x = i * (this.width * 1.0 / data.length); // need to fix x
+            let v = data[i] / 128.0;
+            let y = v * this.height / 2;
+            if(i === 0) this.cctx.moveTo(x,y);
+            else this.cctx.lineTo(x,y);
+        }
+        this.cctx.stroke();
+    }
+    reset(){
+        this.cctx.clearRect(0 , 0, this.width, this.height);
+    }
 }
 export {
-    _initCvs,
-    _primer,
-    _drawRawOsc
+    Renderer
 }


### PR DESCRIPTION
Also enables customization of the `osc` method

This way you can more easily switch to your own renderer while using this library as the “oscilloscope engine”.

It switches to version 4.0.0 because the API is dramatically changed.